### PR TITLE
fix(auth): treat 403 as successful logout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,11 +40,15 @@ export const App = () => {
   const handleOnLogout = () => {
     createAxios()
       .post("/auth/token/logout/")
+      .catch(err => {
+        if (!(err.response && err.response.status === 403)) {
+          throw err;
+        }
+      })
       .then(() => {
         window.localStorage.removeItem("authToken");
         setIsAuthenticated(false);
-      })
-      .catch(console.error);
+      });
   };
 
   return (


### PR DESCRIPTION
The token logout endpoint is protected and thus an invalid logout token (likely from switching between development and production backends) will prevent you from logging out.